### PR TITLE
Accept `root` nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var spaces = require('space-separated-tokens');
 var commas = require('comma-separated-tokens');
 var nan = require('is-nan');
 var is = require('unist-util-is');
+var u = require('unist-builder');
 
 module.exports = wrapper;
 
@@ -18,16 +19,24 @@ function wrapper(h, node, prefix) {
     throw new Error('h is not a function');
   }
 
-  if (!is('element', node)) {
-    var name = node && node.type || node;
-    throw new Error('Expected root or element, not `' + name + '`');
-  }
-
   r = react(h);
   v = vdom(h);
 
   if (prefix === null || prefix === undefined) {
     prefix = r === true || v === true ? 'h-' : false;
+  }
+
+  if (is('root', node)) {
+    if (!Array.isArray(node.children) || node.children.length === 0) {
+      throw new Error('Expected children in root');
+    } else if (node.children.length === 1) {
+      node = node.children[0];
+    } else {
+      node = u('element', {tagName: 'div'}, node.children);
+    }
+  } else if (!is('element', node)) {
+    var name = (node && node.type) || node;
+    throw new Error('Expected root or element, not `' + name + '`');
   }
 
   return toH(h, node, {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function wrapper(h, node, prefix) {
   }
 
   if (!is('element', node)) {
-    throw new Error('Expected element, not `' + node + '`');
+    var name = node && node.type || node;
+    throw new Error('Expected root or element, not `' + name + '`');
   }
 
   r = react(h);

--- a/test.js
+++ b/test.js
@@ -41,6 +41,14 @@ test('hast-to-hyperscript', function (t) {
     st.end();
   });
 
+  t.test('should throw if the root node has 0 children', function (st) {
+    t.throws(function () {
+      toH(h, u('root', {}, []));
+    }, /Expected children in root/);
+
+    st.end();
+  });
+
   hast = u('element', {
     tagName: 'h1',
     properties: {id: 'a', className: ['b', 'c'], hidden: true, height: 2}
@@ -270,6 +278,40 @@ test('hast-to-hyperscript', function (t) {
       {border: '1'},
       'react: should parse an invalid style declaration'
     );
+
+    st.end();
+  });
+
+  t.test('flattens a `root` element with exactly 1 child', function (st) {
+    const uTree = u('root', {}, [
+      u('element', {
+        tagName: 'h1',
+        properties: {id: 'a'}
+      })
+    ]);
+
+    const vTree = toH(v, uTree);
+    st.equal(vTree.tagName, 'H1');
+    st.ok(vTree.properties);
+    st.equal(vTree.properties.id, 'a');
+
+    st.end();
+  });
+
+  t.test('uses a `div` for a `root` element with >1 children', function (st) {
+    const uTree = u('root', {}, [
+      u('element', {
+        tagName: 'h1',
+        properties: {id: 'a'}
+      }),
+      u('element', {
+        tagName: 'p',
+        properties: {id: 'b'}
+      })
+    ]);
+
+    const vTree = toH(v, uTree);
+    st.equal(vTree.tagName, 'DIV');
 
     st.end();
   });

--- a/test.js
+++ b/test.js
@@ -28,15 +28,15 @@ test('hast-to-hyperscript', function (t) {
   t.test('should throw if not given a node', function (st) {
     t.throws(function () {
       toH(h);
-    }, /Expected element, not `undefined`/);
+    }, /Expected root or element, not `undefined`/);
 
     t.throws(function () {
       toH(h, 'text');
-    }, /Error: Expected element, not `text`/);
+    }, /Error: Expected root or element, not `text`/);
 
     t.throws(function () {
       toH(h, u('text', 'value'));
-    }, /Expected element/);
+    }, /Expected root or element/);
 
     st.end();
   });


### PR DESCRIPTION
This PR just uses a `<div>` `element` if there are more than 1 children in the `root` root node.