### PR TITLE
Added Feature: support hast element to be set as a property of other hast element.

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function toH(h, node, ctx) {
   attributes = {}
 
   for (property in properties) {
-    addAttribute(attributes, property, properties[property], ctx)
+    addAttribute(h, attributes, property, properties[property], ctx)
   }
 
   if (
@@ -145,7 +145,7 @@ function toH(h, node, ctx) {
   return result
 }
 
-function addAttribute(props, prop, value, ctx) {
+function addAttribute(h, props, prop, value, ctx) {
   var hyperlike = ctx.hyperscript || ctx.vdom || ctx.vue
   var schema = ctx.schema
   var info = find(schema, prop)
@@ -193,7 +193,11 @@ function addAttribute(props, prop, value, ctx) {
 
     props[subprop][info.attribute] = value
   } else {
-    props[ctx.react && info.space ? info.property : info.attribute] = value
+    props[ctx.react && info.space ? info.property : info.attribute] = element(
+      value
+    )
+      ? toH(h, value, ctx)
+      : value
   }
 }
 
@@ -222,7 +226,6 @@ function vue(h) {
 
 function parseStyle(value, tagName) {
   var result = {}
-
   try {
     style(value, iterator)
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "comma-separated-tokens": "^1.0.0",
     "property-information": "^5.0.0",
     "space-separated-tokens": "^1.0.0",
-    "style-to-object": "^0.2.1",
+    "style-to-object": "0.2.1",
     "unist-util-is": "^3.0.0",
     "web-namespaces": "^1.1.2"
   },

--- a/test.js
+++ b/test.js
@@ -672,6 +672,40 @@ test('hast-to-hyperscript', function(t) {
     st.end()
   })
 
+  t.test('should support hast element set as property', function(st) {
+    const tree = u(
+      'element',
+      {
+        tagName: 'div',
+        properties: {
+          icon: u('element', {
+            tagName: 'div',
+            properties: {
+              avatar: u('element', {tagName: 'span'}, [u('text', 'div text')])
+            }
+          })
+        }
+      },
+      [u('element', {tagName: 'div'})]
+    )
+
+    const expected = r(
+      'div',
+      {
+        key: 'h-3',
+        icon: r('div', {
+          key: 'h-2',
+          avatar: r('span', {key: 'h-1'}, ['div text'])
+        })
+      },
+      [r('div', {key: 'h-4'})]
+    )
+
+    var actual = toH(r, tree)
+    st.deepEqual(json(actual), json(expected), 'equal syntax trees')
+    st.end()
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
## Motivation:
It's useful for a hast element to be set as a property as another element and be interpreted so, currently it gets ignored and interpreted as plain object.

This PR adds this support.

e.g: The icon property will be interpreted as a valid hast element.
```js
{
    type: 'element',
    tagName: 'div',
    properties: {
      color: 'primary',
      icon: {type: 'element', tagName: 'image', properties: {src: 'url'}}
    }
}
```

This allows a hast tree to support the following use case in react, where the icon property is a react element.

 ```jsx
<Tab icon={<PhoneIcon />} label="RECENTS" />
```

One additional temporary fix I need to make in this PR, I had to fix the `style-to-object`'s version to `0.2.1` as recent update breaks original tests.

Thanks for this great library and your time to review!


