### PR TITLE
Update `property-information` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "comma-separated-tokens": "^1.0.0",
-    "property-information": "^5.0.0",
+    "property-information": "^5.3.0",
     "space-separated-tokens": "^1.0.0",
     "style-to-object": "^0.3.0",
     "unist-util-is": "^4.0.0",


### PR DESCRIPTION
The `property-information` package started containing its _hast-to-react.json_ file in v5.3.0. Found this in a project that had `property-info` yarn-locked at 5.0.0 and wasn't updated correctly when including `hast-to-hyperscript` v8.1.0

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/master/support.md
https://github.com/syntax-tree/.github/blob/master/contributing.md
-->
