### PR TITLE
types: ensure catch variable is an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,6 +304,20 @@ function vue(h) {
 }
 
 /**
+ * Checks if an unknown variable is an error
+ *
+ * @param {unknown} maybeError
+ * @returns {maybeError is Error}
+ */
+function isError(maybeError) {
+  return (
+    typeof maybeError === 'object' &&
+    maybeError !== null &&
+    'message' in maybeError
+  )
+}
+
+/**
  * @param {string} value
  * @param {string} tagName
  * @returns {Record<string, string>}
@@ -328,8 +342,11 @@ function parseStyle(value, tagName) {
       ] = value
     })
   } catch (error) {
-    error.message =
-      tagName + '[style]' + error.message.slice('undefined'.length)
+    if (isError(error)) {
+      error.message =
+        tagName + '[style]' + error.message.slice('undefined'.length)
+    }
+
     throw error
   }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

double checks that caught error is of type error

<!--do not edit: pr-->
